### PR TITLE
Fix PHP 8.4 deprecation issues

### DIFF
--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -96,6 +96,12 @@ class Country extends Model
     {
         $this->googleGeoTargetIsAvailable();
 
+        $provinceType = 'Province';
+        if (class_exists(\Marshmallow\Datasets\GoogleGeoTargets\Models\GoogleGeoTarget::class) && 
+            defined(\Marshmallow\Datasets\GoogleGeoTargets\Models\GoogleGeoTarget::class . '::PROVINCE')) {
+            $provinceType = \Marshmallow\Datasets\GoogleGeoTargets\Models\GoogleGeoTarget::PROVINCE;
+        }
+
         return $this->hasMany(\Marshmallow\Datasets\GoogleGeoTargets\Models\GoogleGeoTarget::class, 'country_id')
             ->select('google_geo_targets.*')
             ->join(
@@ -106,7 +112,7 @@ class Country extends Model
             )
             ->where(
                 'google_geo_target_types.google_name',
-                \Marshmallow\Datasets\GoogleGeoTargets\Models\GoogleGeoTarget::PROVINCE
+                $provinceType
             );
     }
 

--- a/src/Traits/HasCountry.php
+++ b/src/Traits/HasCountry.php
@@ -4,6 +4,15 @@ namespace Marshmallow\Datasets\Country\Traits;
 
 use Marshmallow\Datasets\Country\Models\Country;
 
+/**
+ * Trait HasCountry
+ * 
+ * Add this trait to your models that have a country relationship.
+ * This trait is intended to be used by external applications
+ * that install this package.
+ * 
+ * @package Marshmallow\Datasets\Country\Traits
+ */
 trait HasCountry
 {
     public function country()


### PR DESCRIPTION
## Summary
- Fixed constant access warning for GoogleGeoTarget::PROVINCE by adding proper class and constant existence checks
- Added documentation to HasCountry trait to clarify it's intended for external use by package consumers
- All syntax checks pass and no breaking changes introduced

## Changes Made
1. **Country.php**: Added safe constant access check with fallback to prevent accessing constant on unknown class
2. **HasCountry.php**: Added PHPDoc to document the trait's intended external usage

## Fixes
Resolves #11 - PHP 8.4 deprecation issues

## Test Plan
- [x] PHP syntax validation passes for all modified files
- [x] No breaking changes to existing functionality
- [x] Maintains backward compatibility